### PR TITLE
feat(ci): org-wide reusable workflows

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -1,0 +1,25 @@
+﻿name: Backend - Build & Push
+
+on:
+  push:
+    branches: [master, dev, homologation]
+  pull_request:
+    branches: [master, dev, homologation]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: backend-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-build.yml@v1
+    with:
+      image_name: conecta-sla-api
+      dockerfile: dockerfile
+      context: .
+      node_version: '20'

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,47 @@
+﻿name: Backend - Deploy to Homologation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag to deploy (example: v1.2.3)
+        required: true
+      skip_health_check:
+        description: Skip health check
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: backend-deploy-homologation
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1
+    with:
+      deploy_environment: homologation
+      deploy_path: ${{ secrets.DEPLOY_PATH }}
+      service_name: api
+      compose_env_file: .env
+      runtime_env_filename: .env.backend
+      api_image: ghcr.io/${{ github.repository_owner }}/conecta-sla-api
+      api_tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.image_tag }}
+      health_url: ${{ secrets.HEALTH_URL }}
+      health_retries: 10
+      health_interval: 30
+      skip_health_check: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_health_check == 'true' || false }}
+      use_tailscale: true
+    secrets:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+      RUNTIME_ENV_FILE: ${{ secrets.RUNTIME_ENV_FILE }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+      TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -1,0 +1,27 @@
+﻿name: Backend - Create Release
+
+on:
+  workflow_run:
+    workflows: ["Backend - Update Swagger Docs"]
+    types: [completed]
+    branches: [master, dev, homologation]
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Version without v prefix (optional)
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/github-release.yml@v1
+    with:
+      ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      release_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_version || '' }}
+      prerelease: ${{ github.event_name != 'workflow_dispatch' && github.event.workflow_run.head_branch != 'master' }}
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/backend-swagger.yml
+++ b/.github/workflows/backend-swagger.yml
@@ -1,0 +1,31 @@
+﻿name: Backend - Update Swagger Docs
+
+on:
+  workflow_run:
+    workflows: ["Backend - Build & Push"]
+    types: [completed]
+    branches: [master, dev, homologation]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to update docs
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  swagger:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/swagger-pages.yml@v1
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.event.workflow_run.head_branch || github.ref_name }}
+      node_version: '20'
+      swagger_command: npm run generate:swagger
+      swagger_output_dir: swagger
+      publish_pages: true


### PR DESCRIPTION
﻿## Contexto
Migracao dos callers locais para workflows reutilizaveis versionados no repo central.

## Escopo
- backend-build.yml
- backend-swagger.yml
- backend-release.yml
- backend-deploy.yml

## Como testar
- Disparar pipeline em branch de teste
- Validar jobs build/swagger/release/deploy

Closes #10
