### PR TITLE
Refactor de qualidade: testes de chat e groq cloud

### DIFF
--- a/src/chat/chat.controller.spec.ts
+++ b/src/chat/chat.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+import { GroqCloudService } from '../groq-cloud/groq-cloud.service';
 
 describe('ChatController', () => {
   let controller: ChatController;
@@ -7,6 +9,16 @@ describe('ChatController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChatController],
+      providers: [
+        {
+          provide: ChatService,
+          useValue: {},
+        },
+        {
+          provide: GroqCloudService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<ChatController>(ChatController);

--- a/src/chat/chat.service.spec.ts
+++ b/src/chat/chat.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatService } from './chat.service';
+import { getModelToken } from '@nestjs/mongoose';
 
 describe('ChatService', () => {
   let service: ChatService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ChatService],
+      providers: [
+        ChatService,
+        {
+          provide: getModelToken('Chat'),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<ChatService>(ChatService);

--- a/src/groq-cloud/groq-cloud.service.spec.ts
+++ b/src/groq-cloud/groq-cloud.service.spec.ts
@@ -1,12 +1,54 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GroqCloudService } from './groq-cloud.service';
+import { ConfigService } from '@nestjs/config';
+import { RagService } from '../rag/rag.service';
+import { AiTelemetryService } from '../rag/ai-telemetry.service';
 
 describe('GroqCloudService', () => {
   let service: GroqCloudService;
 
   beforeEach(async () => {
+    process.env.GROQ_API_KEY = 'test-key';
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GroqCloudService],
+      providers: [
+        GroqCloudService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'GROQ_API_KEY') {
+                return 'test-key';
+              }
+              if (key === 'LLM_PROVIDER') {
+                return 'groq';
+              }
+              if (key === 'GROQ_MODEL') {
+                return 'llama3-8b-8192';
+              }
+              return undefined;
+            }),
+          },
+        },
+        {
+          provide: RagService,
+          useValue: {
+            getContextPayload: jest.fn().mockResolvedValue({
+              query: 'test',
+              collection: 'rag',
+              k: 3,
+              chunks: [],
+              generatedAt: new Date().toISOString(),
+            }),
+            formatContextForPrompt: jest.fn().mockReturnValue(''),
+          },
+        },
+        {
+          provide: AiTelemetryService,
+          useValue: {
+            trace: jest.fn().mockImplementation(async (_n, _p, fn) => fn()),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<GroqCloudService>(GroqCloudService);


### PR DESCRIPTION
## Contexto
Ajustes de testes de regressao para acompanhar o refactor dos modulos de chat e provider de IA.

## Escopo
- Atualizacao de `src/chat/chat.controller.spec.ts`
- Atualizacao de `src/chat/chat.service.spec.ts`
- Atualizacao de `src/groq-cloud/groq-cloud.service.spec.ts`

## Como testar
1. Executar suite de testes unitarios
2. Validar mocks e cenarios de erro/sucesso

Refs #12
Refs #7