### PR TITLE
Governanca de artefatos locais (RAG/Swagger)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Local data/artifacts (RAG, generated docs)
+raw/
+storage/
+swagger/swagger.json
+output.md


### PR DESCRIPTION
## Contexto
Definicao de governanca para evitar versionamento acidental de artefatos locais e binarios pesados.

## Escopo
- Atualizacao de `.gitignore` para ignorar:
  - `raw/`
  - `storage/`
  - `swagger/swagger.json`
  - `output.md`

## Como testar
1. Gerar artefatos localmente
2. Validar que `git status` nao lista esses arquivos

Refs #23
Refs #7