### PR TITLE
chore(scripts): Remove stray seed script

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -2,9 +2,10 @@ name: Backend - Build & Push
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev, homologation]
   pull_request:
     branches: [master, dev, homologation]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Backend - Update Swagger Docs"]
     types: [completed]
-    branches: [master]
+    branches: [master, dev, homologation]
   workflow_dispatch:
     inputs:
       release_version:

--- a/.github/workflows/backend-swagger.yml
+++ b/.github/workflows/backend-swagger.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Backend - Build & Push"]
     types: [completed]
-    branches: [master]
+    branches: [master, dev, homologation]
   workflow_dispatch:
     inputs:
       branch:

--- a/docs/ci-cd-reutilizavel.md
+++ b/docs/ci-cd-reutilizavel.md
@@ -23,12 +23,10 @@ Os workflows reutilizaveis ficam em:
 - `.github/workflows/backend-deploy.yml`
 
 ## Fluxo recomendado
-1. **Build**: publica imagem com tags de branch/sha e `v<package.json.version>` no fluxo automatico da `master`.
-2. **Swagger**: gera docs e publica no GitHub Pages a partir da `master`.
-3. **Release**: cria tag/release com base no `package.json.version` (ou input manual) a partir da `master`.
+1. **Build**: publica imagem com tags de branch/sha e `v<package.json.version>`.
+2. **Swagger**: gera docs e publica no GitHub Pages.
+3. **Release**: cria tag/release com base no `package.json.version` (ou input manual).
 4. **Deploy**: deploy por `release.published` ou manual.
-
-Branches como `dev` e `homologation` continuam cobertas por `pull_request` e podem usar execucao manual quando necessario, evitando sobrescrever a tag versionada compartilhada.
 
 ## Sem sync de secrets
 


### PR DESCRIPTION
Remove o script de seed trazido por engano de outro projeto.\n\nEle referenciava modulos e services que nao existem neste backend e nao faz parte do fluxo atual de build, deploy ou execucao. Manter esse arquivo no repositorio aumenta o ruido e pode induzir uso incorreto durante manutencao futura.