### PR TITLE
ci(compose): Support image-based homeserver deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 PORT=3000
 CORS_ORIGIN=http://localhost:4000
+API_IMAGE=coguide-api
+API_TAG=local
 
 DB_URI=mongodb://localhost:27017/coguide
 JWT_SECRET=change-me

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   api:
+    image: ${API_IMAGE:-coguide-api}:${API_TAG:-local}
     build:
       context: .
       dockerfile: dockerfile


### PR DESCRIPTION
Add API_IMAGE and API_TAG support to docker-compose so the homeserver can pull and run the published GHCR image while preserving local docker compose up --build usage. Also document the default image variables in .env.example for local and CI parity.