### PR TITLE
ci(deploy): Upgrade deploy workflow to v1.6

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy:
-    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1.5
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1.6
     with:
       deploy_environment: homologation
       deploy_path: ${{ vars.DEPLOY_PATH }}


### PR DESCRIPTION
Move the homolog deploy caller to reusable-workflows v1.6 so it consumes the reusable parsing fix for the optional Discord webhook condition.