### PR TITLE
ci(deploy): Prepare compose for homeserver runtime

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy:
-    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1.6
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1.7
     with:
       deploy_environment: homologation
       deploy_path: ${{ vars.DEPLOY_PATH }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,54 @@
 services:
   api:
     image: ${API_IMAGE:-coguide-api}:${API_TAG:-local}
-    build:
-      context: .
-      dockerfile: dockerfile
     container_name: coguide-api
     restart: unless-stopped
     env_file:
-      - .env
+      - .env.backend
     environment:
       PORT: 3000
       DB_URI: mongodb://mongo:27017/coguide
       RAG_CHROMA_URL: http://chroma:8000
       OLLAMA_BASE_URL: http://ollama:11434
     ports:
-      - "3000:3000"
-    volumes:
-      - ./raw:/app/raw:ro
+      - "127.0.0.1:3000:3000"
     depends_on:
-      - mongo
-      - chroma
+      mongo:
+        condition: service_healthy
+      chroma:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   mongo:
     image: mongo:7
     container_name: coguide-mongo
     restart: unless-stopped
-    ports:
-      - "27017:27017"
     volumes:
       - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok' | grep 1"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
 
   chroma:
     image: chromadb/chroma:0.5.23
     container_name: coguide-chroma
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     volumes:
       - chroma_data:/chroma/chroma
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8000/api/v1/heartbeat >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
 
   ollama:
     image: ollama/ollama:latest


### PR DESCRIPTION
Adjust docker-compose for image-based homeserver deploys by using .env.backend as the application env, removing the local raw bind mount, limiting published ports, and adding health checks for the API and backing services. Also upgrade the deploy caller to reusable-workflows v1.7 so compose environment variables are written reliably during SSH deploys.