### PR TITLE
ci(release): Prepare homologation flow for v0.1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ PORT=3000
 CORS_ORIGIN=http://localhost:4000
 API_IMAGE=coguide-api
 API_TAG=local
+API_HOST_PORT=3002
 
 DB_URI=mongodb://localhost:27017/coguide
 JWT_SECRET=change-me

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,8 +1,10 @@
 name: Backend - Deploy to Homologation
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Backend - Create Release"]
+    types: [completed]
+    branches: [homologation]
   workflow_dispatch:
     inputs:
       image_tag:
@@ -22,6 +24,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-deploy-ssh.yml@v1.7
     with:
       deploy_environment: homologation
@@ -30,7 +33,7 @@ jobs:
       compose_env_file: .env
       runtime_env_filename: .env.backend
       api_image: ghcr.io/gabrimeireles/coguide-api
-      api_tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.image_tag }}
+      api_tag: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.inputs.image_tag }}
       health_url: ${{ vars.HEALTH_URL }}
       health_retries: 10
       health_interval: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       RAG_CHROMA_URL: http://chroma:8000
       OLLAMA_BASE_URL: http://ollama:11434
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${API_HOST_PORT:-3002}:3000"
     depends_on:
       mongo:
         condition: service_healthy
@@ -55,8 +55,6 @@ services:
     container_name: coguide-ollama
     restart: unless-stopped
     profiles: ["local-embeddings"]
-    ports:
-      - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "co-guide_pps_back-end",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "co-guide_pps_back-end",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@langchain/community": "^0.2.31",
@@ -13074,7 +13074,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "co-guide_pps_back-end",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Bump the backend version to 0.1.0 and align the compose defaults with a free host port for the homeserver.

Switch the homologation deploy workflow to trigger from the release workflow chain instead of relying on a published release event, so the pipeline can continue automatically on the homologation branch.